### PR TITLE
Route multicast connections

### DIFF
--- a/os/net/lwip/src/core/ipv4/ip.c
+++ b/os/net/lwip/src/core/ipv4/ip.c
@@ -164,7 +164,8 @@ struct netif *ip_route(ip_addr_t *dest)
 	for (netif = netif_list; netif != NULL; netif = netif->next) {
 		/* network mask matches? */
 		if (netif_is_up(netif)) {
-			if (dest->addr == 0xffffffff || ip_addr_netcmp(dest, &(netif->ip_addr), &(netif->netmask))) {
+			if (dest->addr == 0xffffffff || ip_addr_ismulticast(dest) ||
+          ip_addr_netcmp(dest, &(netif->ip_addr), &(netif->netmask))) {
 				/* return netif on which to forward IP packet */
 				return netif;
 			}


### PR DESCRIPTION
Dirty hack to pass multicast connections. To resolve this issue permanently LWIP must be updated.

Signed-off-by: Krzysztof Antoszek <k.antoszek@samsung.com>